### PR TITLE
Add prioritisation exclusive enumeration

### DIFF
--- a/Example/Listenable-Example/ListenableObject.swift
+++ b/Example/Listenable-Example/ListenableObject.swift
@@ -19,7 +19,8 @@ class ListenableObject: Listenable<ListenableObjectDelegate> {
     
     /// Calls listenableObjectDidProvideUpdate on all registered listeners.
     func updateAllListeners() {
-        self.updateListeners{ (listener, index) in
+        
+        self.updateListeners(withPriority: .high) { (listener, index) in
             listener.listenableObjectDidProvideUpdate(self)
         }
     }

--- a/Example/Listenable-Example/ListenerViewController.swift
+++ b/Example/Listenable-Example/ListenerViewController.swift
@@ -21,7 +21,7 @@ class ListenerViewController: UIViewController, ListenableObjectDelegate {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        self.listenableObject.add(listeners: [self, self.actionButton], priority: .low)
+        self.listenableObject.add(listeners: [self, self.actionButton], priority: .high)
     }
     
     // MARK: Actions

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Enumerate & Update Listeners:
 Listeners can also be updated exclusively relative to their priority:
 ```swift
 	updateListeners(withPriority: ListenerPriority?, 
-					   update: (listener: Listener, index: Int) -> Void)
+				    	  update: (listener: Listener, index: Int) -> Void)
 					   
 	updateListeners(withPriorities: ClosedRange<Int>?, 
-						update: (listener: Listener, index: Int) -> Void)
+				    	    update: (listener: Listener, index: Int) -> Void)
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Remove Listener(s):
 ```
 Enumerate & Update Listeners:
 ```swift
-	updateListeners(updateBlock: (listener: Listener, index: Int) -> Void)
+	updateListeners(update: (listener: Listener, index: Int) -> Void)
 ```
+
 #### Prioritisation
 `ListenerPriority` allows for definition of enumeration priority for a listener; by default the `priority` parameter is set to `.low`. The following values can be assigned:
 ```swift
@@ -45,6 +46,16 @@ Enumerate & Update Listeners:
 	.high 		(Raw: 1000)
 	.custom		(Valid range: 0-1000)
 ```
+
+Listeners can also be updated exclusively relative to their priority:
+```swift
+	updateListeners(withPriority: ListenerPriority?, 
+					   update: (listener: Listener, index: Int) -> Void)
+					   
+	updateListeners(withPriorities: ClosedRange<Int>?, 
+						update: (listener: Listener, index: Int) -> Void)
+```
+
 ## Contributing
 Bug reports and pull requests are welcome on GitHub at https://github.com/MerrickSapsford/Listenable.
 

--- a/Sources/ListenableTests/ListenableTests.swift
+++ b/Sources/ListenableTests/ListenableTests.swift
@@ -156,6 +156,54 @@ class ListenableTests: XCTestCase {
                   "Listener with out of range -1 priority was not ceiled to 0 and inserted at the end of the low priority queue.")
     }
     
+    func testExclusivePriorityUpdating() {
+        let lowPriorityListeners = [TestListener(), TestListener(), TestListener()]
+        let highPriorityListeners = [TestListener(), TestListener()]
+        
+        self.listenableObject.add(listeners: lowPriorityListeners, priority: .low)
+        self.listenableObject.add(listeners: highPriorityListeners, priority: .high)
+        
+        var updateCount = 0
+        self.listenableObject.updateListeners(withPriority: .high) { (listener, index) in
+            updateCount += 1
+        }
+        
+        XCTAssert(updateCount == highPriorityListeners.count,
+                  "Exclusive ListenerPriority updating is including incorrect priorities")
+    }
+    
+    func testExclusivePriorityRangeUpdating() {
+        let listeners = [TestListener(), TestListener(), TestListener()]
+        
+        self.listenableObject.add(listener: listeners[0], priority: .custom(value: 10))
+        self.listenableObject.add(listener: listeners[1], priority: .custom(value: 15))
+        self.listenableObject.add(listener: listeners[2], priority: .custom(value: 20))
+
+        var updateCount = 0
+        self.listenableObject.updateListeners(withPriorities: 16...20) { (listener, index) in
+            updateCount += 1
+        }
+        
+        XCTAssert(updateCount == 1,
+                  "Exclusive range prioritised updating is including incorrect priorities")
+    }
+    
+    func testExclusivePriorityRangeOutOfBoundsUpdating() {
+        let listeners = [TestListener(), TestListener(), TestListener()]
+
+        self.listenableObject.add(listener: listeners[0], priority: .low)
+        self.listenableObject.add(listener: listeners[1], priority: .custom(value: 500))
+        self.listenableObject.add(listener: listeners[2], priority: .high)
+        
+        var updateCount = 0
+        self.listenableObject.updateListeners(withPriorities: 1001...5000) { (listener, index) in
+            updateCount += 1
+        }
+        
+        XCTAssert(updateCount == 0,
+                  "Exclusive range prioritised updating is including incorrect priorities")
+    }
+    
     // MARK: Remove listeners
     
     func testRemoveListener() {

--- a/Sources/ListenableTests/ListenableTests.swift
+++ b/Sources/ListenableTests/ListenableTests.swift
@@ -28,7 +28,7 @@ class ListenableTests: XCTestCase {
         self.listenableObject = TestListenableObject()
     }
     
-    // MARK: Add listeners
+    // MARK: Adding
     
     func testAddListener() {
         let initialListenerCount = self.listenableObject.listenerCount
@@ -156,55 +156,7 @@ class ListenableTests: XCTestCase {
                   "Listener with out of range -1 priority was not ceiled to 0 and inserted at the end of the low priority queue.")
     }
     
-    func testExclusivePriorityUpdating() {
-        let lowPriorityListeners = [TestListener(), TestListener(), TestListener()]
-        let highPriorityListeners = [TestListener(), TestListener()]
-        
-        self.listenableObject.add(listeners: lowPriorityListeners, priority: .low)
-        self.listenableObject.add(listeners: highPriorityListeners, priority: .high)
-        
-        var updateCount = 0
-        self.listenableObject.updateListeners(withPriority: .high) { (listener, index) in
-            updateCount += 1
-        }
-        
-        XCTAssert(updateCount == highPriorityListeners.count,
-                  "Exclusive ListenerPriority updating is including incorrect priorities")
-    }
-    
-    func testExclusivePriorityRangeUpdating() {
-        let listeners = [TestListener(), TestListener(), TestListener()]
-        
-        self.listenableObject.add(listener: listeners[0], priority: .custom(value: 10))
-        self.listenableObject.add(listener: listeners[1], priority: .custom(value: 15))
-        self.listenableObject.add(listener: listeners[2], priority: .custom(value: 20))
-
-        var updateCount = 0
-        self.listenableObject.updateListeners(withPriorities: 16...20) { (listener, index) in
-            updateCount += 1
-        }
-        
-        XCTAssert(updateCount == 1,
-                  "Exclusive range prioritised updating is including incorrect priorities")
-    }
-    
-    func testExclusivePriorityRangeOutOfBoundsUpdating() {
-        let listeners = [TestListener(), TestListener(), TestListener()]
-
-        self.listenableObject.add(listener: listeners[0], priority: .low)
-        self.listenableObject.add(listener: listeners[1], priority: .custom(value: 500))
-        self.listenableObject.add(listener: listeners[2], priority: .high)
-        
-        var updateCount = 0
-        self.listenableObject.updateListeners(withPriorities: 1001...5000) { (listener, index) in
-            updateCount += 1
-        }
-        
-        XCTAssert(updateCount == 0,
-                  "Exclusive range prioritised updating is including incorrect priorities")
-    }
-    
-    // MARK: Remove listeners
+    // MARK: Removal
     
     func testRemoveListener() {
         let listeners = self.addTestListeners(count: 1,
@@ -254,7 +206,7 @@ class ListenableTests: XCTestCase {
                   "All listeners were not removed successfully")
     }
     
-    // MARK: Enumerate listeners
+    // MARK: Enumeration
     
     func testEnumerateAllListeners() {
         let proposedListenerCount = Int(arc4random_uniform(maxListenerCount) + 1)
@@ -292,6 +244,54 @@ class ListenableTests: XCTestCase {
         
         XCTAssert((evaluatedListenerCount == 1) && (addedListenerCount == 2) && (postEnumerationCount == addedListenerCount - 1),
                   "Destroyed listeners are not being removed during the enumeration operation successfully")
+    }
+    
+    func testEnumerateExclusivePriorityUpdating() {
+        let lowPriorityListeners = [TestListener(), TestListener(), TestListener()]
+        let highPriorityListeners = [TestListener(), TestListener()]
+        
+        self.listenableObject.add(listeners: lowPriorityListeners, priority: .low)
+        self.listenableObject.add(listeners: highPriorityListeners, priority: .high)
+        
+        var updateCount = 0
+        self.listenableObject.updateListeners(withPriority: .high) { (listener, index) in
+            updateCount += 1
+        }
+        
+        XCTAssert(updateCount == highPriorityListeners.count,
+                  "Exclusive ListenerPriority updating is including incorrect priorities")
+    }
+    
+    func testEnumerateExclusivePriorityRangeUpdating() {
+        let listeners = [TestListener(), TestListener(), TestListener()]
+        
+        self.listenableObject.add(listener: listeners[0], priority: .custom(value: 10))
+        self.listenableObject.add(listener: listeners[1], priority: .custom(value: 15))
+        self.listenableObject.add(listener: listeners[2], priority: .custom(value: 20))
+        
+        var updateCount = 0
+        self.listenableObject.updateListeners(withPriorities: 16...20) { (listener, index) in
+            updateCount += 1
+        }
+        
+        XCTAssert(updateCount == 1,
+                  "Exclusive range prioritised updating is including incorrect priorities")
+    }
+    
+    func testEnumerateExclusivePriorityRangeOutOfBoundsUpdating() {
+        let listeners = [TestListener(), TestListener(), TestListener()]
+        
+        self.listenableObject.add(listener: listeners[0], priority: .low)
+        self.listenableObject.add(listener: listeners[1], priority: .custom(value: 500))
+        self.listenableObject.add(listener: listeners[2], priority: .high)
+        
+        var updateCount = 0
+        self.listenableObject.updateListeners(withPriorities: 1001...5000) { (listener, index) in
+            updateCount += 1
+        }
+        
+        XCTAssert(updateCount == 0,
+                  "Exclusive range prioritised updating is including incorrect priorities")
     }
     
     // MARK: Utils


### PR DESCRIPTION
- Add `priorities` `ClosedRange<Int>` parameter to `updateListeners` to allow
for prioritisation exclusive updating.

- Add convenience function `updateListeners(withPriority: )` to allow
for `ListenerPriority` values to be used for exclusive updating

Resolves #10 